### PR TITLE
EXO-812 Add 0342 error code Invalid setting identifier

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -136,6 +136,7 @@ error categories, the last two digits define specific errors.
 * 0339: Email is already in use
 * 0340: Not supported country
 * 0341: Invalid postal code
+* 0342: Invalid setting identifier
 
 ### System Limit Errors: 04 (HTTP 400)
 * 0401: Incorrect price, below the minimum


### PR DESCRIPTION
New required error code for invalid settings identifiers.

Signed-off-by: Victor Cruz <victorcruz@Bitsos-MacBook-Pro.local>