### PR TITLE
Fix a bug

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -75,8 +75,7 @@ We return decimal numbers as strings to preserve full precision across platforms
 ## Rate Limits
 
 Rate limits are based on one minute windows. For public API requests, the limit is by IP address and allows 60 requests per minute. For private API requests, the limit is by user and allows 300
-requests per minute. If you exceed these limits, you will get locked out for
-one minute. Continuous one minute lockouts may result in a 24-hour block. Order cancellations aren’t subject to API rate limiting.
+requests per minute. If you exceed these limits, you will get locked out for one minute. Continuous one minute lockouts may result in a 24-hour block. Order cancellations aren’t subject to API rate limiting.
 
 ## Error Codes
 


### PR DESCRIPTION
For some reason the break line was making the rate limit section
not to appear. This fixes the error.

Signed-off-by: Victor Cruz <victorcruz@Bitsos-MacBook-Pro.local>