### PR TITLE
Added error 1103

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -210,7 +210,7 @@ error categories, the last two digits define specific errors.
 ### Operation Errors: 11 (500 error)
 * 1101: Error when processing the withdrawal
 * 1102: Error registering callback URL
-* 1103: System wide method is disabled
+* 1103: System-wide method disabled
 
 ## Client Libraries
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -210,6 +210,7 @@ error categories, the last two digits define specific errors.
 ### Operation Errors: 11 (500 error)
 * 1101: Error when processing the withdrawal
 * 1102: Error registering callback URL
+* 1103: System wide method is disabled
 
 ## Client Libraries
 


### PR DESCRIPTION
This will now indicate that the method for withdrawal/deposit is currently disabled globally. 
Such as a contingency measure or other serious problems with processing withdrawals or deposits.

# Related PR
https://github.com/bitsoex/bitsoex/pull/3271