### PR TITLE
Remove misleading information

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1511,7 +1511,6 @@ Field Name | Type | Description | Units
         "method": "btc",
         "amount": "0.48650929",
         "details": {
-            "funding_address": "18MsnATiNiKLqUHDTRKjurwMg7inCrdNEp",
             "tx_hash": "d4f28394693e9fb5fffcaf730c11f32d1922e5837f76ca82189d3bfe30ded433"
         }
     }, {


### PR DESCRIPTION
We do not return funding address in the details of any funding

``` PHP
Hi Bitso people. I'm looking at the response from /fundings ... the documentation at https://bitso.com/api_info#fundings implies that there should be a funding_address in details. However, I don't see the address included for any XRP deposits. Can you please clarify?
```

While this request is not bad, ATM we are showing wrong info.

Signed-off-by: Victor Cruz <victorcruz@Bitsos-MacBook-Pro.local>