### PR TITLE
Use openssl with -binary instead of -hex and pipe it to xxd 

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -598,7 +598,7 @@ DNONCE=$(date +%s)
 HTTPmethod=GET
 JSONPayload=""
 RequestPath="/v3/balance/"
-SIGNATURE=$(echo -n $DNONCE$HTTPmethod$RequestPath$JSONPayload | openssl dgst -hex -sha256 -hmac $API_SECRET )
+SIGNATURE=$(echo -n $DNONCE$HTTPmethod$RequestPath$JSONPayload | openssl dgst -binary -sha256 -hmac $API_SECRET | xxd -p -c 256 )
 AUTH_HEADER="Bitso $API_KEY:$DNONCE:$SIGNATURE"
 http GET $URL Authorization:"$AUTH_HEADER"
 ```


### PR DESCRIPTION
Current OpenSSL version appends the `(stdin)= ` prefix to the HMAC hash when using the `-hex` option, which breaks the current signature generation script in the docs. 

This PR uses instead the `-binary` option and pipes the result to the `xxd` command to make it more future proof, as it looks to be a recurring issue: https://unix.stackexchange.com/questions/42797/openssl-dgst-sha1-producing-an-extraneous-stdin-prefix-and-trailing-new 