### PR TITLE
Aint 890: Add validation for Stop Amounts

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -217,6 +217,8 @@ error categories, the last two digits define specific errors.
 * 0408: Incorrect amount value, it must be a non-zero positive value.
 * 0410: Trading not enabled
 * 0411: Trading not enabled for market orders
+* 0412: Incorrect stop, below the minimum
+* 0413: Incorrect stop, above the maximum
 
 
 ### User Limit Error: 05 (HTTP 400)


### PR DESCRIPTION
Add validation for Stop Amounts server side, as only limit amounts are validated.

Due to a missing server-side validation, it is possible to manipulate the stop-loss amount by using an intercepting proxy. The user can either set it less than the minimum or more than the maximum amount allowed by the application.

Jira Ticket:
https://bitsomx.atlassian.net/secure/RapidBoard.jspa?rapidView=101&projectKey=AUSD&modal=detail&selectedIssue=AINT-890

Code Changes:
https://github.com/bitsoex/bitsoex/pull/4175