### PR TITLE
BITA-941 Be more explicit in the errors the API is returning for max allowed pairing devices

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -119,7 +119,7 @@ error categories, the last two digits define specific errors.
 * 0202: API key is not authorized to execute the requested method
 * 0203: Login token is invalid or expired
 * 0204: Incorrect PIN
-* 0205: Too many login attempts 
+* 0205: Too many login attempts
 * 0206: Invalid nonce type
 * 0207: Invalid nonce value
 * 0208: Authentication is required to execute requested operation
@@ -247,6 +247,7 @@ error categories, the last two digits define specific errors.
 * 0717: Incorrect value for users business persons(s) types
 * 0718: User business person doesn't belongs to the user
 * 0719: User's PGP key not found
+* 0720: The maximum number of paired devices has been reached
 
 ### Throttling Errors: 08 (HTTP 420)
 * 0801: You have hit the request rate-limit


### PR DESCRIPTION
## Description
A report emerged in slack (https://bitso.slack.com/archives/G2QJUKX33/p1593529054407500), which implied the fact that the maximum number of devices linked to a user account had been reached, however, the message was not clear, so a more explicit message is handled in this PR to indicate the particular situation of the error.

## JIRA
https://bitsomx.atlassian.net/browse/BITA-941

## Code changed in
https://github.com/bitsoex/bitsoex/pull/4567