### PR TITLE
BITA-2142: new error code when deleting user beneficiaries

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -250,6 +250,7 @@ error categories, the last two digits define specific errors.
 * 0719: User's PGP key not found
 * 0720: The maximum number of paired devices has been reached
 * 0721: Error when performing a security action (i.e. block withdrawals)
+* 0722: Error deleting user beneficiary
 
 ### Throttling Errors: 08 (HTTP 420)
 * 0801: You have hit the request rate-limit


### PR DESCRIPTION
## Issue tracker links

- [BITA-2142: H1 - Users could delete all beneficiaries from the database](https://bitsomx.atlassian.net/browse/BITA-2142)

## Description: 
- Adds a new error to describe there's an error when deleting a beneficiary

## Dependencies 
Depends on https://github.com/bitsoex/bitsoex/pull/4913
