### PR TITLE
[AS2-120] set book as not mandatory for user_trades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 2.0.1
+
+*July 19, 2021*
+
+Documentation inconsistency between REST Api service and implementation was fixed:
+* in user_trades service documentation, now 'book' is not required.
+
 ## Version 2.0.0
 
 *July 9, 2021*

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -25,6 +25,11 @@ system functions, along with examples in common programming languages.
 
 # Changelog
 
+### 2021-07-19
+Documentation inconsistency between REST Api service and implementation was fixed:
+
+* in user_trades service documentation, now 'book' is not required.
+
 ### 2021-06-25
 
 There was an inconsistency for Diff-Orders and for Orders API. The "t" field was being described as number 0 for selling
@@ -35,7 +40,7 @@ This update was for documentation only, nothing changes in the consumer side.
 ### 2021-06-24
 
 Fixed documentation inconsistency between REST Api service and the implementation:
-* in user_trades service documentation, now 'book' is required.
+
 * in order_trades service documentation the field 'make_side' have changed to 'maker_side'
 * also in the same service the 'created_at' field format have been upgraded from 2021-06-11T09:25:05+0000 to 2021-06-11T09:25:05.000+00:00
 
@@ -1681,7 +1686,7 @@ This endpoint returns a list of the user's trades.
 
 Parameter | Default | Required | Description
 --------- | ------- | -------- | -----------
-**book** |   | Yes | Specifies which book to use
+**book** |   | No | Specifies which book to use
 **marker** |  | No | Returns objects that are older or newer (depending on 'sort') than the object with this ID
 **sort** | desc | No | Specifies ordering direction of returned objects
 **limit** | 25 | No | Specifies number of objects to return. (Max is 100)


### PR DESCRIPTION
PR - Set Book parameter as Not Mandatory for User-Trades endpoint
Jira Task: https://bitsomx.atlassian.net/browse/AS2-120

## Changes/solution

This PR contains the following features:
- Set book as a not mandatory field for User Trades

## Notes and considerations
- Deployed API: https://bitsoex.github.io/slate/#user-trades
- Incident: https://bitsomx.pagerduty.com/incidents/PQ17MVK
