### PR TITLE
BSHIFT-726: Added new validation error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
+## Version 2.0.4
+*December 7, 2021*
 
+Added new validation error code 0375 reserved for internal use of Shift API
 
 ## Version 2.0.3
 *November 24, 2021*

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -237,7 +237,7 @@ error categories, the last two digits define specific errors.
 * 0372: Incorrect value type for field
 * 0373: Request has expired
 * 0374: Invalid 2FA recovery code
-* 0375: Invalid routing number
+* 0375: Invalid routing number - `This code is reserved for internal use`
 
 
 ### System Limit Errors: 04 (HTTP 400)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -237,7 +237,7 @@ error categories, the last two digits define specific errors.
 * 0372: Incorrect value type for field
 * 0373: Request has expired
 * 0374: Invalid 2FA recovery code
-* 0375: Invalid routing number - `This code is reserved for internal use`
+* 0375: Reserved for internal use
 
 
 ### System Limit Errors: 04 (HTTP 400)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -237,6 +237,7 @@ error categories, the last two digits define specific errors.
 * 0372: Incorrect value type for field
 * 0373: Request has expired
 * 0374: Invalid 2FA recovery code
+* 0375: Invalid routing number
 
 
 ### System Limit Errors: 04 (HTTP 400)


### PR DESCRIPTION
## Issue tracker links
[BSHIFT-726](https://bitsomx.atlassian.net/browse/BSHIFT-726)

## Changes/solution
- Added new validation error code for indicating wrong routing numbers for bank accounts created in Circle.
- For example this error code will be used when the user try to use an ACH routing number to create a Wire account
- This is related to PR https://github.com/bitsoex/bitso-exchange-java/pull/7447 and https://github.com/bitsoex/bitsoex/pull/5970, which in turn are related to this incident https://bitsomx.pagerduty.com/incidents/Q3OTKJXY2H1ULB and related ones. The intention is to give the UI some hint to be able to show the user what happened and how they can correct the data to be able to authorize the account