### PR TITLE
Including a new error code for fingerprint validation

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -245,6 +245,7 @@ error categories, the last two digits define specific errors.
 * 0374: Invalid 2FA recovery code
 * 0375: Reserved for internal use
 * 0376: Limit of Bitso Transfer reached
+* 0377: Fingerprint doesn't meet security requirements
 
 
 ### System Limit Errors: 04 (HTTP 400)


### PR DESCRIPTION
Including a new error code for fingerprint validation

0377: Fingerprint doesn't meet security requirements